### PR TITLE
docs: add CI status and reference badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ A small Go library for sending messages to Telegram and handling Telegram Bot we
 
 This repository is intended to be used as a building block inside Telegram bots or services that need to interact with Telegram.
 
+## Status
+
+[![Build](https://github.com/br0-space/bot-telegramclient/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/br0-space/bot-telegramclient/actions/workflows/build.yml)
+[![Test](https://github.com/br0-space/bot-telegramclient/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/br0-space/bot-telegramclient/actions/workflows/test.yml)
+[![Lint](https://github.com/br0-space/bot-telegramclient/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/br0-space/bot-telegramclient/actions/workflows/lint.yml)
+[![Staticcheck](https://github.com/br0-space/bot-telegramclient/actions/workflows/staticcheck.yml/badge.svg?branch=main)](https://github.com/br0-space/bot-telegramclient/actions/workflows/staticcheck.yml)
+[![Vet](https://github.com/br0-space/bot-telegramclient/actions/workflows/vet.yml/badge.svg?branch=main)](https://github.com/br0-space/bot-telegramclient/actions/workflows/vet.yml)
+[![CodeQL](https://github.com/br0-space/bot-telegramclient/actions/workflows/codeql-analysis.yml/badge.svg?branch=main)](https://github.com/br0-space/bot-telegramclient/actions/workflows/codeql-analysis.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/br0-space/bot-telegramclient.svg)](https://pkg.go.dev/github.com/br0-space/bot-telegramclient)
+[![Go Report Card](https://goreportcard.com/badge/github.com/br0-space/bot-telegramclient)](https://goreportcard.com/report/github.com/br0-space/bot-telegramclient)
+
 
 ## Installation
 


### PR DESCRIPTION
This PR adds a Status section to the README including badges for build, test, lint, staticcheck, vet, CodeQL, Go Reference, and Go Report Card.\n\n- Scope: docs only (README.md)\n- Rationale: Improves project visibility and quick health checks\n- No code changes\n\nPlease review and merge if acceptable.